### PR TITLE
Update Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.13.0 AS builder
-LABEL stage="versioner-builder-env"
+FROM golang:1.18.0 AS builder
 WORKDIR /tmp/app
 COPY . .
 RUN make release
@@ -7,4 +6,3 @@ RUN make release
 FROM busybox:1.31.1
 WORKDIR /app
 COPY --from=builder /tmp/app/bin/versioner .
-ENTRYPOINT [ "./versioner" ]


### PR DESCRIPTION
This PR updates the Go version in the `Dockerfile` and removes the redundant `entrypoint` entry.